### PR TITLE
added return value to ordered_guarded::modify

### DIFF
--- a/src/libguarded/ordered_guarded.hpp
+++ b/src/libguarded/ordered_guarded.hpp
@@ -15,6 +15,7 @@
 
 #include <memory>
 #include <mutex>
+#include <utility>
 
 #if HAVE_CXX14
 #include <shared_mutex>
@@ -59,7 +60,7 @@ class ordered_guarded
     ordered_guarded(Us &&... data);
 
     template <typename Func>
-    void modify(Func && func);
+    decltype(std::declval<Func>()(std::declval<T>())) modify(Func && func) ;
 
     shared_handle lock_shared() const;
     shared_handle try_lock_shared() const;
@@ -103,11 +104,11 @@ ordered_guarded<T, M>::ordered_guarded(Us &&... data) : m_obj(std::forward<Us>(d
 
 template <typename T, typename M>
 template <typename Func>
-void ordered_guarded<T, M>::modify(Func && func)
+decltype(std::declval<Func>()(std::declval<T>())) ordered_guarded<T, M>::modify(Func && func)
 {
     std::lock_guard<M> lock(m_mutex);
 
-    func(m_obj);
+    return func(m_obj);
 }
 
 template <typename T, typename M>


### PR DESCRIPTION
It simply forwards the return value of the callable to the caller of modify
There is no impact for callables returning void